### PR TITLE
Made python3 compatible using futurize

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ port-forwarder
 
 Simple Python scripts to listen, log and forward network traffic
 
+This script supports python 2 and 3 by making use of `future` which should be installed using `pip install future`.
+
 Usage
 -----
 * Use forward-tcp.py to forward TCP traffic

--- a/forward-tcp.py
+++ b/forward-tcp.py
@@ -1,6 +1,9 @@
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
 import socket
 import sys
-import thread
+import _thread
 
 listen_host = "192.168.0.100"
 listen_port = 8080
@@ -9,8 +12,8 @@ target_host = "127.0.0.1"
 target_port = 64153
 
 def main():
-    thread.start_new_thread(server, () )
-    lock = thread.allocate_lock()
+    _thread.start_new_thread(server, () )
+    lock = _thread.allocate_lock()
     lock.acquire()
     lock.acquire()
 
@@ -19,22 +22,22 @@ def server(*settings):
         dock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         dock_socket.bind((listen_host, listen_port)) # listen
         dock_socket.listen(5)
-        print "*** listening on %s:%i" % ( listen_host, listen_port )
+        print("*** listening on %s:%i" % ( listen_host, listen_port ))
         while True:
             client_socket, client_address = dock_socket.accept()
-            print "*** from %s:%i to %s:%i" % ( client_address, listen_port, target_host, target_port )
+            print("*** from %s:%i to %s:%i" % ( client_address, listen_port, target_host, target_port ))
             server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             server_socket.connect((target_host, target_port))
-            thread.start_new_thread(forward, (client_socket, server_socket, "client -> server" ))
-            thread.start_new_thread(forward, (server_socket, client_socket, "server -> client" ))
+            _thread.start_new_thread(forward, (client_socket, server_socket, "client -> server" ))
+            _thread.start_new_thread(forward, (server_socket, client_socket, "server -> client" ))
     finally:
-        thread.start_new_thread(server, () )
+        _thread.start_new_thread(server, () )
 
 def forward(source, destination, description):
     data = ' '
     while data:
         data = source.recv(1024)
-        print "*** %s: %s" % ( description, data )
+        print("*** %s: %s" % ( description, data ))
         if data:
             destination.sendall(data)
         else:

--- a/forward-udp.py
+++ b/forward-udp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 import socket
 bufsize = 1024 
@@ -10,15 +11,15 @@ listen_host = "192.168.0.103"
 listen_port = 8080
 
 def forward(data, port):
-    print "*** Forwarding: '%s' from port %s" % (data, port)
-    sock = socket.socket(AF_INET, SOCK_DGRAM)
+    print("*** Forwarding: '%s' from port %s" % (data, port))
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(("localhost", port)) # Bind to the port data came in on
     sock.sendto(data, (target_host, target_port))
 
 def listen(host, port):
-    listen_socket = socket.socket(AF_INET, SOCK_DGRAM)
+    listen_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     listen_socket.bind((host, port))
-    print "*** Listening on %s:%s" % ( host, port )
+    print("*** Listening on %s:%s" % ( host, port ))
     while True:
         data, addr = listen_socket.recvfrom(bufsize)
         forward(data, addr[1]) # data and port

--- a/proxy.py
+++ b/proxy.py
@@ -1,4 +1,10 @@
-import socket, thread, select
+from __future__ import division
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+from past.utils import old_div
+import socket, _thread, select
 
 __version__ = '0.1.0 Draft 1'
 BUFLEN = 8192
@@ -6,7 +12,7 @@ VERSION = 'Python Proxy/'+__version__
 HTTPVER = 'HTTP/1.1'
 HOST = "192.168.0.103" 
 
-class ConnectionHandler:
+class ConnectionHandler(object):
     def __init__(self, connection, address, timeout):
         self.client = connection
         self.client_buffer = ''
@@ -26,7 +32,7 @@ class ConnectionHandler:
             end = self.client_buffer.find('\n')
             if end!=-1:
                 break
-        print '%s'%self.client_buffer[:end]#debug
+        print('%s'%self.client_buffer[:end])#debug
         data = (self.client_buffer[:end+1]).split()
         self.client_buffer = self.client_buffer[end+1:]
         return data
@@ -61,7 +67,7 @@ class ConnectionHandler:
         self.target.connect(address)
 
     def _read_write(self):
-        time_out_max = self.timeout/3
+        time_out_max = old_div(self.timeout,3)
         socs = [self.client, self.target]
         count = 0
         while 1:
@@ -90,10 +96,10 @@ def start_server(host='localhost', port=8080, IPv6=False, timeout=60,
         soc_type=socket.AF_INET
     soc = socket.socket(soc_type)
     soc.bind((host, port))
-    print "Serving on %s:%d."%(host, port)#debug
+    print("Serving on %s:%d."%(host, port))#debug
     soc.listen(0)
     while 1:
-        thread.start_new_thread(handler, soc.accept()+(timeout,))
+        _thread.start_new_thread(handler, soc.accept()+(timeout,))
 
 if __name__ == '__main__':
     start_server( host=HOST )


### PR DESCRIPTION
Made the scripts python3 compatible using futurize

You may need to install `future` as pip package to run now, but it will work on python3 and python2

Fixes #1 

If you just want to completely go over to python3, just remove the future imports (may needs some extra edits as well, tho)